### PR TITLE
Feature/allow keep delimiters

### DIFF
--- a/src/SlugGenerator.php
+++ b/src/SlugGenerator.php
@@ -77,7 +77,7 @@ class SlugGenerator implements SlugGeneratorInterface
 			return '';
 		}
 
-		/** @phpstan-ignore-next-line */
+		/** @var string $text */
 		$text = \Normalizer::normalize($text, \Normalizer::FORM_C);
 		$text = $this->removeIgnored($text, $options->getIgnoreChars());
 		$text = $this->transform($text, $options->getValidChars(), $options->getTransforms(), $options->getLocale());

--- a/src/SlugOptions.php
+++ b/src/SlugOptions.php
@@ -60,6 +60,9 @@ class SlugOptions implements \IteratorAggregate
 	 */
 	private $setOptions = [];
 
+    private bool $keepBeginningDelimiter = false;
+    private bool $keepEndDelimiter = false;
+
 	/**
 	 * @param iterable<string,mixed> $options See the setter methods for available options
 	 */
@@ -287,6 +290,32 @@ class SlugOptions implements \IteratorAggregate
 		return $this;
 	}
 
+    public function setKeepBeginningDelimiter(bool $keepBeginingDelimiter): self
+    {
+        $this->keepBeginningDelimiter = $keepBeginingDelimiter;
+        $this->setOptions['keepBeginningDelimiter'] = null;
+
+        return $this;
+    }
+
+    public function getKeepBeginningDelimiter(): bool
+    {
+        return $this->keepBeginningDelimiter;
+    }
+
+    public function setKeepEndDelimiter(bool $keepEndDelimiter): self
+    {
+        $this->keepEndDelimiter = $keepEndDelimiter;
+        $this->setOptions['keepEndDelimiter'] = null;
+
+        return $this;
+    }
+
+    public function getKeepEndDelimiter(): bool
+    {
+        return $this->keepEndDelimiter;
+    }
+
 	/**
 	 * @throws \InvalidArgumentException If it’s an invalid option name
 	 */
@@ -300,6 +329,8 @@ class SlugOptions implements \IteratorAggregate
 			'transforms',
 			'preTransforms',
 			'postTransforms',
+            'keepBeginningDelimiter',
+            'keepEndDelimiter',
 		];
 
 		if (!\in_array($option, $validOptions, true)) {

--- a/tests/SlugGeneratorTest.php
+++ b/tests/SlugGeneratorTest.php
@@ -249,6 +249,54 @@ class SlugGeneratorTest extends TestCase
 					'preTransforms' => ['ö > OOOO'],
 				],
 			],
+            [
+                '_sugiartoss_',
+                'sugiartoss-',
+                [
+                    'keepEndDelimiter' => true
+                ]
+            ],
+            [
+                '_sugiartoss_',
+                '-sugiartoss',
+                [
+                    'keepBeginningDelimiter' => true
+                ]
+            ],
+            [
+                '_sugiartoss_',
+                '-sugiartoss-',
+                [
+                    'keepBeginningDelimiter' => true,
+                    'keepEndDelimiter' => true
+                ]
+            ],
+            [
+                '-sugiartoss-',
+                'sugiartoss-',
+                [
+                    'keepEndDelimiter' => true
+                ]
+            ],
+            [
+                '-sugiartoss-',
+                '-sugiartoss',
+                [
+                    'keepBeginningDelimiter' => true
+                ]
+            ],
+            [
+                '-sugiartoss-',
+                '-sugiartoss-',
+                [
+                    'keepBeginningDelimiter' => true,
+                    'keepEndDelimiter' => true
+                ]
+            ],
+            [
+                '-sugiartoss-',
+                'sugiartoss',
+            ],
 		];
 	}
 

--- a/tests/SlugOptionsTest.php
+++ b/tests/SlugOptionsTest.php
@@ -280,7 +280,9 @@ class SlugOptionsTest extends TestCase
 	{
 		$options = new SlugOptions(['transforms' => []]);
 
-		$this->expectException($expectedException);
+		if ($expectedException) {
+			$this->expectException($expectedException);
+		}
 
 		$this->assertSame([$transform], $options->addTransform($transform)->getTransforms());
 	}
@@ -318,5 +320,20 @@ class SlugOptionsTest extends TestCase
 			/** @phpstan-ignore-next-line */
 			$this->expectExceptionMessageRegExp($regularExpression);
 		}
+	}
+
+    public function testSetKeepDelimiter(): void
+	{
+		$options = new SlugOptions;
+		$this->assertFalse($options->getKeepBeginningDelimiter());
+		$this->assertFalse($options->getKeepEndDelimiter());
+		$this->assertTrue($options->setKeepBeginningDelimiter(true)->getKeepBeginningDelimiter());
+		$this->assertTrue($options->setKeepEndDelimiter(true)->getKeepEndDelimiter());
+
+		$options = new SlugOptions(['keepBeginningDelimiter' => true, 'keepEndDelimiter' => true]);
+        $this->assertTrue($options->getKeepBeginningDelimiter());
+		$this->assertTrue($options->getKeepEndDelimiter());
+		$this->assertFalse($options->setKeepBeginningDelimiter(false)->getKeepBeginningDelimiter());
+		$this->assertFalse($options->setKeepEndDelimiter(false)->getKeepEndDelimiter());
 	}
 }


### PR DESCRIPTION
This is my idea of implementation form the issue #34 . It allows to control if want to strip delimiter just from beginning, from the end,  both or none of them